### PR TITLE
random seq but ordered by nonce within the same sender

### DIFF
--- a/execute.py
+++ b/execute.py
@@ -6,6 +6,8 @@ import matplotlib.pyplot as plt
 from ordering import *
 from aequitas import *
 import copy
+import json
+from web3 import Web3
 
 tx_mapping = {}
 
@@ -53,7 +55,7 @@ def same_order(txs):
     return txs
 
 def process_example_uniswap_transactions(data_file, order_function):
-
+    w3 = Web3(Web3.HTTPProvider("https://mainnet.infura.io/v3/af1d3ad9016c423282f5875d6e2dc6a7"))
 
     # Very messy parser of transactions in plaintext into objects
     transactions = []
@@ -134,8 +136,16 @@ def process_example_uniswap_transactions(data_file, order_function):
     for i in range(1):
         # Leader maliciously shuffling
         for node in nodes_seen:
-            seq = [x[0] for x in nodes_seen[node]]
-            random.shuffle(seq)
+            seq = []
+            for x in nodes_seen[node]:
+                # get txn data
+                txn_data = json.loads(Web3.toJSON(w3.eth.get_transaction(x[0].txid)))
+                # append to seq as a tuple, first element is the txn and second is the nonce
+                seq.append((x[0], txn_data["nonce"]))
+            # sort by non-decreasing nonce
+            seq.sort(key=lambda s: s[1])
+            # remove the nonce so seq is just a list of txn with non-decreasing nonce
+            seq = [x[0] for x in seq]
             node_order_sequence = TransactionSequence(seq)
             node_order = node_order_sequence.get_output_with_tagged_metrics(node)
 


### PR DESCRIPTION
before this commit, the transaction sequence for each node is random as seen in 
```
seq = [x[0] for x in nodes_seen[node]]
random.shuffle(seq)
```
we want to the sequence to be random but in the nonce order *only for each sender address*, not across all the senders

In addition, the infura URL is under my account so it is probably better to have it replaced. 